### PR TITLE
Fix Xcode project architecture for 64 bit

### DIFF
--- a/jpgcompressor.xcodeproj/project.pbxproj
+++ b/jpgcompressor.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 			baseConfigurationReference = 24DD6D1B1134B66800162E58 /* titanium.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/ComSideshowcoderJpgcompressor.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -225,6 +225,7 @@
 				GCC_PREFIX_HEADER = ComSideshowcoderJpgcompressor_Prefix.pch;
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = ComSideshowcoderJpgcompressor;
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Debug;
 		};
@@ -233,13 +234,14 @@
 			baseConfigurationReference = 24DD6D1B1134B66800162E58 /* titanium.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				DSTROOT = /tmp/ComSideshowcoderJpgcompressor.dst;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ComSideshowcoderJpgcompressor_Prefix.pch;
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = ComSideshowcoderJpgcompressor;
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Should be fine now :)
~~~
(jpgcompressor)--(master*)
$ xcrun lipo -info build/libcom.sideshowcoder.jpgcompressor.a 
Architectures in the fat file: build/libcom.sideshowcoder.jpgcompressor.a are: armv7 i386 x86_64 arm64 
~~~